### PR TITLE
Add charset option to Content-Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Example config for serving local files in "/tmp" under "/prefix", eg GET /prefix
 
 start_link() ->
     FileserveConfig = [{prefix, <<"/prefix">>},
-                       {path, <<"/tmp">>}],
+                       {path, <<"/tmp">>},
+                       {charset, "utf-8"}],
 
     Config = [{mods, [{elli_fileserve, FileserveConfig}]}],
 


### PR DESCRIPTION
Hi Chris,

thought it would be nice to support adding a configurable charset field to the Content-Type header.

Cheers,
Martin
