### PR TITLE
Add missing export for file_size/1

### DIFF
--- a/src/elli_fileserve.erl
+++ b/src/elli_fileserve.erl
@@ -12,6 +12,9 @@
 
 -export([handle/2, handle_event/3]).
 
+%% exported for mockability in tests (called through ?MODULE)
+-export([file_size/1]).
+
 -ifdef(TEST).
 -compile([export_all]).
 -endif.


### PR DESCRIPTION
Sorry, here's an important fixup for https://github.com/chrisavl/elli_fileserve/pull/4

I overlooked you had `export_all` for the tests ... so we need that export to make it work outside of the tests ;-)

Cheers,
Martin
